### PR TITLE
Replace hero image with card component

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -30,6 +30,7 @@ import {
 } from "lucide-react"
 import Link from "next/link"
 import Image from "next/image"
+import HeroCard from "@/components/hero-card"
 
 const CheckIcon = () => <CheckCircle2 className="h-5 w-5 text-green-500" />
 const CrossIcon = () => <XCircle className="h-5 w-5 text-red-500" />
@@ -133,14 +134,8 @@ export default function TokenForgePage() {
                   </MotionButton>
                 </motion.div>
               </div>
-                <motion.div variants={itemVariants} className="mx-auto md:mx-0">
-                <Image
-                  src="/heroimage.png"
-                  alt="TokenForge interface screenshot"
-                  width={900}
-                  height={600}
-                  className="w-full rounded-xl border border-border/20 shadow-lg object-cover"
-                />
+              <motion.div variants={itemVariants} className="mx-auto md:mx-0">
+                <HeroCard />
               </motion.div>
             </div>
           </div>

--- a/components/hero-card.tsx
+++ b/components/hero-card.tsx
@@ -1,0 +1,63 @@
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
+
+export default function HeroCard() {
+  return (
+    <Card className="w-full rounded-xl border border-border/20 shadow-lg">
+      <CardHeader>
+        <CardTitle>Forge Tokens</CardTitle>
+        <CardDescription>Create Leaderboard</CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="text-sm">
+          <span className="font-medium">L2 Trending:</span>{" "}
+          $CAST <span className="text-green-500">+8.6%</span>{" "}
+          $LCH <span className="text-green-500">+6.7%</span>{" "}
+          $BOUNCE <span className="text-green-500">+5%</span>{" "}
+          $EKHO <span className="text-green-500">+1%</span>
+        </div>
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Token</TableHead>
+              <TableHead>Age</TableHead>
+              <TableHead className="text-right">Market Cap</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            <TableRow>
+              <TableCell>Cast</TableCell>
+              <TableCell>3s</TableCell>
+              <TableCell className="text-right">$217K</TableCell>
+            </TableRow>
+            <TableRow>
+              <TableCell>Change</TableCell>
+              <TableCell>17s</TableCell>
+              <TableCell className="text-right">$646K</TableCell>
+            </TableRow>
+            <TableRow>
+              <TableCell>Bounce</TableCell>
+              <TableCell>20s</TableCell>
+              <TableCell className="text-right">$511K</TableCell>
+            </TableRow>
+            <TableRow>
+              <TableCell>Drips</TableCell>
+              <TableCell>1m</TableCell>
+              <TableCell className="text-right">$413K</TableCell>
+            </TableRow>
+            <TableRow>
+              <TableCell>Blythe</TableCell>
+              <TableCell>6m</TableCell>
+              <TableCell className="text-right">$990K</TableCell>
+            </TableRow>
+            <TableRow>
+              <TableCell>Vogue</TableCell>
+              <TableCell>8m</TableCell>
+              <TableCell className="text-right">$16K</TableCell>
+            </TableRow>
+          </TableBody>
+        </Table>
+      </CardContent>
+    </Card>
+  )
+}


### PR DESCRIPTION
## Summary
- convert hero screenshot to new `HeroCard` component
- display `HeroCard` in the hero section instead of the image

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68487d29d1548321b00dd474bc7c7b6a