### PR TITLE
Improve hero card icons

### DIFF
--- a/components/hero-card.tsx
+++ b/components/hero-card.tsx
@@ -1,16 +1,30 @@
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
+import { Coins, Star } from "lucide-react"
 
 export default function HeroCard() {
   return (
-    <Card className="w-full rounded-xl border border-border/20 shadow-lg">
+    <Card className="w-full rounded-xl border border-border/20 bg-card/80 backdrop-blur shadow-xl">
       <CardHeader>
         <CardTitle>Forge Tokens</CardTitle>
         <CardDescription>Create Leaderboard</CardDescription>
       </CardHeader>
       <CardContent className="space-y-4">
-        <div className="text-sm">
-          <span className="font-medium">L2 Trending:</span>{" "}
+        <div className="text-sm text-muted-foreground">
+          <span className="font-medium">Trending:</span>{" "}
           $CAST <span className="text-green-500">+8.6%</span>{" "}
           $LCH <span className="text-green-500">+6.7%</span>{" "}
           $BOUNCE <span className="text-green-500">+5%</span>{" "}
@@ -26,32 +40,56 @@ export default function HeroCard() {
           </TableHeader>
           <TableBody>
             <TableRow>
-              <TableCell>Cast</TableCell>
+              <TableCell className="flex items-center gap-2">
+                <Star className="h-4 w-4 text-yellow-400" />
+                <Coins className="h-4 w-4 text-primary" />
+                <span>Cast</span>
+              </TableCell>
               <TableCell>3s</TableCell>
               <TableCell className="text-right">$217K</TableCell>
             </TableRow>
             <TableRow>
-              <TableCell>Change</TableCell>
+              <TableCell className="flex items-center gap-2">
+                <Star className="h-4 w-4 text-yellow-400" />
+                <Coins className="h-4 w-4 text-primary" />
+                <span>Change</span>
+              </TableCell>
               <TableCell>17s</TableCell>
               <TableCell className="text-right">$646K</TableCell>
             </TableRow>
             <TableRow>
-              <TableCell>Bounce</TableCell>
+              <TableCell className="flex items-center gap-2">
+                <Star className="h-4 w-4 text-yellow-400" />
+                <Coins className="h-4 w-4 text-primary" />
+                <span>Bounce</span>
+              </TableCell>
               <TableCell>20s</TableCell>
               <TableCell className="text-right">$511K</TableCell>
             </TableRow>
             <TableRow>
-              <TableCell>Drips</TableCell>
+              <TableCell className="flex items-center gap-2">
+                <Star className="h-4 w-4 text-yellow-400" />
+                <Coins className="h-4 w-4 text-primary" />
+                <span>Drips</span>
+              </TableCell>
               <TableCell>1m</TableCell>
               <TableCell className="text-right">$413K</TableCell>
             </TableRow>
             <TableRow>
-              <TableCell>Blythe</TableCell>
+              <TableCell className="flex items-center gap-2">
+                <Star className="h-4 w-4 text-yellow-400" />
+                <Coins className="h-4 w-4 text-primary" />
+                <span>Blythe</span>
+              </TableCell>
               <TableCell>6m</TableCell>
               <TableCell className="text-right">$990K</TableCell>
             </TableRow>
             <TableRow>
-              <TableCell>Vogue</TableCell>
+              <TableCell className="flex items-center gap-2">
+                <Star className="h-4 w-4 text-yellow-400" />
+                <Coins className="h-4 w-4 text-primary" />
+                <span>Vogue</span>
+              </TableCell>
               <TableCell>8m</TableCell>
               <TableCell className="text-right">$16K</TableCell>
             </TableRow>


### PR DESCRIPTION
## Summary
- add star and token icons to the hero card token rows
- modernize styling and tweak trending label

## Testing
- `pnpm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848811489408321949918ec93fed163