### PR TITLE
Add launch modal using shadcn Card

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -32,6 +32,7 @@ import {
 import Link from "next/link"
 import Image from "next/image"
 import HeroCard from "@/components/hero-card"
+import LaunchModal from "@/components/launch-modal"
 
 const CheckIcon = () => <CheckCircle2 className="h-5 w-5 text-green-500" />
 const CrossIcon = () => <XCircle className="h-5 w-5 text-red-500" />
@@ -125,16 +126,15 @@ export default function TokenForgePage() {
                   tools. Launch on Solana, Base, or Avalanche without writing a single line of code.
                 </motion.p>
                 <motion.div variants={itemVariants} className="mt-10 flex flex-col sm:flex-row md:justify-start justify-center gap-4">
-                  <MotionButton
-                    {...buttonInteractionProps}
-                    size="lg"
-                    asChild
-                    className="bg-primary text-primary-foreground hover:bg-primary/90"
-                  >
-                    <Link href="#">
+                  <LaunchModal>
+                    <MotionButton
+                      {...buttonInteractionProps}
+                      size="lg"
+                      className="bg-primary text-primary-foreground hover:bg-primary/90"
+                    >
                       Launch Your Token, Now <Rocket className="ml-2 h-4 w-4" />
-                    </Link>
-                  </MotionButton>
+                    </MotionButton>
+                  </LaunchModal>
                   <MotionButton {...buttonInteractionProps} size="lg" variant="outline">
                     Watch Live Launches <Eye className="ml-2 h-4 w-4" />
                   </MotionButton>

--- a/components/launch-modal.tsx
+++ b/components/launch-modal.tsx
@@ -1,0 +1,144 @@
+"use client"
+
+import { useState } from "react"
+import { useForm } from "react-hook-form"
+import {
+  Dialog,
+  DialogContent,
+  DialogTrigger,
+} from "@/components/ui/dialog"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { Textarea } from "@/components/ui/textarea"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+
+interface LaunchForm {
+  name: string
+  symbol: string
+  supply: string
+  chain: string
+  mechanics: string
+}
+
+const steps = ["Name", "Symbol", "Supply", "Chain", "Mechanics"]
+
+interface LaunchModalProps {
+  children: React.ReactNode
+}
+
+export default function LaunchModal({ children }: LaunchModalProps) {
+  const form = useForm<LaunchForm>({
+    defaultValues: {
+      name: "",
+      symbol: "",
+      supply: "",
+      chain: "",
+      mechanics: "",
+    },
+  })
+  const [step, setStep] = useState(0)
+
+  const next = () => setStep((s) => Math.min(s + 1, steps.length - 1))
+  const back = () => setStep((s) => Math.max(s - 1, 0))
+
+  const onSubmit = (values: LaunchForm) => {
+    console.log("Submitted", values)
+  }
+
+  return (
+    <Dialog>
+      <DialogTrigger asChild>{children}</DialogTrigger>
+      <DialogContent className="p-0 border-none bg-transparent">
+        <Card className="max-w-xl mx-auto">
+          <CardHeader>
+            <CardTitle>{`Step ${step + 1} of ${steps.length}: ${steps[step]}`}</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+              {step === 0 && (
+                <div className="space-y-2">
+                  <label className="text-sm font-medium" htmlFor="name">
+                    Token Name
+                  </label>
+                  <Input id="name" {...form.register("name", { required: true })} />
+                </div>
+              )}
+              {step === 1 && (
+                <div className="space-y-2">
+                  <label className="text-sm font-medium" htmlFor="symbol">
+                    Symbol
+                  </label>
+                  <Input id="symbol" {...form.register("symbol", { required: true })} />
+                </div>
+              )}
+              {step === 2 && (
+                <div className="space-y-2">
+                  <label className="text-sm font-medium" htmlFor="supply">
+                    Total Supply
+                  </label>
+                  <Input
+                    id="supply"
+                    type="number"
+                    {...form.register("supply", { required: true })}
+                  />
+                </div>
+              )}
+              {step === 3 && (
+                <div className="space-y-2">
+                  <label className="text-sm font-medium" htmlFor="chain">
+                    Chain
+                  </label>
+                  <Select
+                    value={form.watch("chain")}
+                    onValueChange={(value) => form.setValue("chain", value)}
+                  >
+                    <SelectTrigger id="chain">
+                      <SelectValue placeholder="Select a chain" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="solana">Solana</SelectItem>
+                      <SelectItem value="base">Base</SelectItem>
+                      <SelectItem value="avalanche">Avalanche</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+              )}
+              {step === 4 && (
+                <div className="space-y-2">
+                  <label className="text-sm font-medium" htmlFor="mechanics">
+                    Mechanics
+                  </label>
+                  <Textarea id="mechanics" {...form.register("mechanics")} />
+                </div>
+              )}
+              <div className="flex justify-between pt-4">
+                {step > 0 && (
+                  <Button type="button" variant="secondary" onClick={back}>
+                    Back
+                  </Button>
+                )}
+                {step < steps.length - 1 && (
+                  <Button type="button" onClick={next} className="ml-auto">
+                    Next
+                  </Button>
+                )}
+                {step === steps.length - 1 && (
+                  <Button type="submit" className="ml-auto">
+                    Submit
+                  </Button>
+                )}
+              </div>
+            </form>
+          </CardContent>
+        </Card>
+      </DialogContent>
+    </Dialog>
+  )
+}


### PR DESCRIPTION
## Summary
- add a LaunchModal component that uses shadcn `Dialog` and `Card`
- open the modal from the hero section of the homepage
- include shadcn button dependency via `npx shadcn@latest add button`

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_684890957f0c8321adb0a89b9893c3f1