### PR TITLE
Update launch forms to use shadcn card styling

### DIFF
--- a/app/launch/page.tsx
+++ b/app/launch/page.tsx
@@ -39,7 +39,7 @@ export default function LaunchPage() {
 
   return (
     <div className="container mx-auto max-w-xl py-10">
-      <Card>
+      <Card className="rounded-xl border border-border/20 bg-card/80 backdrop-blur shadow-xl">
         <CardHeader>
           <CardTitle>{`Step ${step + 1} of ${steps.length}: ${steps[step]}`}</CardTitle>
         </CardHeader>

--- a/components/launch-modal.tsx
+++ b/components/launch-modal.tsx
@@ -56,7 +56,7 @@ export default function LaunchModal({ children }: LaunchModalProps) {
     <Dialog>
       <DialogTrigger asChild>{children}</DialogTrigger>
       <DialogContent className="p-0 border-none bg-transparent">
-        <Card className="max-w-xl mx-auto">
+        <Card className="max-w-xl mx-auto rounded-xl border border-border/20 bg-card/80 backdrop-blur shadow-xl">
           <CardHeader>
             <CardTitle>{`Step ${step + 1} of ${steps.length}: ${steps[step]}`}</CardTitle>
           </CardHeader>


### PR DESCRIPTION
## Summary
- adjust card style in LaunchModal to match shadcn design
- match Launch page card with same style

## Testing
- `pnpm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848966d6dbc83219edfd8f400ad53fd