### PR TITLE
Add interactive LiquidGlass component

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -48,3 +48,19 @@
     --ring: 216 12.2% 83.9%;
   }
 }
+
+@layer utilities {
+  @keyframes ripple {
+    from { opacity: 0.4; transform: scale(0); }
+    to { opacity: 0; transform: scale(8); }
+  }
+  .animate-ripple {
+    animation: ripple 0.6s ease-out;
+  }
+  .liquid-ripple {
+    position: absolute;
+    pointer-events: none;
+    border-radius: 9999px;
+    transform: translate(-50%, -50%);
+  }
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -33,6 +33,7 @@ import Link from "next/link"
 import Image from "next/image"
 import HeroCard from "@/components/hero-card"
 import LaunchModal from "@/components/launch-modal"
+import LiquidGlass from "@/components/liquid-glass"
 
 const CheckIcon = () => <CheckCircle2 className="h-5 w-5 text-green-500" />
 const CrossIcon = () => <XCircle className="h-5 w-5 text-red-500" />
@@ -142,6 +143,14 @@ export default function TokenForgePage() {
               </div>
               <motion.div variants={itemVariants} className="mx-auto md:mx-0">
                 <HeroCard />
+              </motion.div>
+              <motion.div variants={itemVariants} className="mx-auto mt-8 md:mx-0">
+                <LiquidGlass className="max-w-md">
+                  <h3 className="text-xl font-semibold">Liquid Glass UI</h3>
+                  <p className="mt-1 text-sm text-muted-foreground">
+                    Experience the Apple-inspired effect.
+                  </p>
+                </LiquidGlass>
               </motion.div>
             </div>
           </div>

--- a/components/liquid-glass.tsx
+++ b/components/liquid-glass.tsx
@@ -1,0 +1,92 @@
+"use client"
+
+import { useEffect, useRef, useState } from "react"
+import { motion, useReducedMotion } from "framer-motion"
+import { cn } from "@/lib/utils"
+
+interface LiquidGlassProps {
+  className?: string
+  children?: React.ReactNode
+}
+
+export default function LiquidGlass({ className, children }: LiquidGlassProps) {
+  const ref = useRef<HTMLDivElement>(null)
+  const shouldReduce = useReducedMotion()
+  const [tilt, setTilt] = useState({ x: 0, y: 0 })
+  const [ripples, setRipples] = useState<{ x: number; y: number; id: number }[]>([])
+
+  useEffect(() => {
+    if (shouldReduce) return
+    const el = ref.current
+    if (!el) return
+    function handleMove(e: PointerEvent) {
+      const rect = el.getBoundingClientRect()
+      const x = (e.clientX - rect.left - rect.width / 2) / rect.width
+      const y = (e.clientY - rect.top - rect.height / 2) / rect.height
+      setTilt({ x: y * 10, y: -x * 10 })
+    }
+    function reset() {
+      setTilt({ x: 0, y: 0 })
+    }
+    el.addEventListener("pointermove", handleMove)
+    el.addEventListener("pointerleave", reset)
+    return () => {
+      el.removeEventListener("pointermove", handleMove)
+      el.removeEventListener("pointerleave", reset)
+    }
+  }, [shouldReduce])
+
+  function createRipple(e: React.MouseEvent<HTMLDivElement>) {
+    const rect = e.currentTarget.getBoundingClientRect()
+    const x = e.clientX - rect.left
+    const y = e.clientY - rect.top
+    const id = Date.now()
+    setRipples((r) => [...r, { x, y, id }])
+    setTimeout(() => setRipples((r) => r.filter((p) => p.id !== id)), 600)
+  }
+
+  return (
+    <motion.div
+      ref={ref}
+      onClick={createRipple}
+      style={{ rotateX: tilt.x, rotateY: tilt.y }}
+      className={cn(
+        "group relative overflow-hidden rounded-3xl border border-white/30 bg-white/10 p-6 backdrop-blur-xl shadow-lg",
+        "transition-transform ease-[cubic-bezier(.22,1,.36,1)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/30",
+        className
+      )}
+      initial={false}
+      animate={
+        shouldReduce
+          ? undefined
+          : { scale: [1, 1.02, 1], opacity: [1, 0.95, 1] }
+      }
+      transition={{ duration: 4, repeat: Infinity, ease: "easeInOut" }}
+    >
+      <div className="pointer-events-none absolute inset-0 -z-10" aria-hidden>
+        <div
+          className="glass-layer absolute inset-0 bg-white/40" // 40% opacity
+          style={{ transform: `translate(${tilt.y * -0.5}px, ${tilt.x * -0.5}px)` }}
+        />
+        <div
+          className="glass-layer absolute inset-4 bg-white/20" // 20% opacity
+          style={{ transform: `translate(${tilt.y * -1}px, ${tilt.x * -1}px)` }}
+        />
+        <div
+          className="glass-layer absolute inset-8 bg-white/10" // 10% opacity
+          style={{ transform: `translate(${tilt.y * -1.5}px, ${tilt.x * -1.5}px)` }}
+        />
+      </div>
+      {ripples.map((r) => (
+        <span
+          key={r.id}
+          style={{ left: r.x, top: r.y }}
+          className="liquid-ripple absolute h-5 w-5 bg-white/20 animate-ripple"
+        />
+      ))}
+      <div className="relative z-10 flex flex-col items-center text-sm text-foreground">
+        {children}
+      </div>
+    </motion.div>
+  )
+}


### PR DESCRIPTION
## Summary
- implement `LiquidGlass` Apple‑style frosted glass card
- expose ripple animation CSS utilities
- showcase the new component on the homepage

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6848b47cd6088321a7e6907b7be55828