### PR TITLE
Apply glass effect to cards and remove demo

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -33,7 +33,6 @@ import Link from "next/link"
 import Image from "next/image"
 import HeroCard from "@/components/hero-card"
 import LaunchModal from "@/components/launch-modal"
-import LiquidGlass from "@/components/liquid-glass"
 
 const CheckIcon = () => <CheckCircle2 className="h-5 w-5 text-green-500" />
 const CrossIcon = () => <XCircle className="h-5 w-5 text-red-500" />
@@ -143,14 +142,6 @@ export default function TokenForgePage() {
               </div>
               <motion.div variants={itemVariants} className="mx-auto md:mx-0">
                 <HeroCard />
-              </motion.div>
-              <motion.div variants={itemVariants} className="mx-auto mt-8 md:mx-0">
-                <LiquidGlass className="max-w-md">
-                  <h3 className="text-xl font-semibold">Liquid Glass UI</h3>
-                  <p className="mt-1 text-sm text-muted-foreground">
-                    Experience the Apple-inspired effect.
-                  </p>
-                </LiquidGlass>
               </motion.div>
             </div>
           </div>

--- a/components/liquid-glass.tsx
+++ b/components/liquid-glass.tsx
@@ -1,23 +1,26 @@
 "use client"
 
-import { useEffect, useRef, useState } from "react"
+import * as React from "react"
+import { useEffect, useRef, useState, useImperativeHandle } from "react"
 import { motion, useReducedMotion } from "framer-motion"
 import { cn } from "@/lib/utils"
 
-interface LiquidGlassProps {
+interface LiquidGlassProps extends React.HTMLAttributes<HTMLDivElement> {
   className?: string
   children?: React.ReactNode
 }
 
-export default function LiquidGlass({ className, children }: LiquidGlassProps) {
-  const ref = useRef<HTMLDivElement>(null)
+const LiquidGlass = React.forwardRef<HTMLDivElement, LiquidGlassProps>(
+  ({ className, children, ...props }, ref) => {
+  const localRef = useRef<HTMLDivElement>(null)
+  useImperativeHandle(ref, () => localRef.current as HTMLDivElement)
   const shouldReduce = useReducedMotion()
   const [tilt, setTilt] = useState({ x: 0, y: 0 })
   const [ripples, setRipples] = useState<{ x: number; y: number; id: number }[]>([])
 
   useEffect(() => {
     if (shouldReduce) return
-    const el = ref.current
+    const el = localRef.current
     if (!el) return
     function handleMove(e: PointerEvent) {
       const rect = el.getBoundingClientRect()
@@ -47,7 +50,7 @@ export default function LiquidGlass({ className, children }: LiquidGlassProps) {
 
   return (
     <motion.div
-      ref={ref}
+      ref={localRef}
       onClick={createRipple}
       style={{ rotateX: tilt.x, rotateY: tilt.y }}
       className={cn(
@@ -89,4 +92,8 @@ export default function LiquidGlass({ className, children }: LiquidGlassProps) {
       </div>
     </motion.div>
   )
-}
+})
+
+LiquidGlass.displayName = "LiquidGlass"
+
+export default LiquidGlass

--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -1,20 +1,42 @@
+"use client"
+
 import * as React from "react"
 
 import { cn } from "@/lib/utils"
+import { useTheme } from "next-themes"
+import LiquidGlass from "@/components/liquid-glass"
 
 const Card = React.forwardRef<
   HTMLDivElement,
   React.HTMLAttributes<HTMLDivElement>
->(({ className, ...props }, ref) => (
-  <div
-    ref={ref}
-    className={cn(
-      "rounded-lg border bg-card text-card-foreground shadow-sm",
-      className
-    )}
-    {...props}
-  />
-))
+>(({ className, children, ...props }, ref) => {
+  const { theme } = useTheme()
+
+  if (theme === "dark") {
+    return (
+      <div
+        ref={ref}
+        className={cn(
+          "rounded-lg border bg-card text-card-foreground shadow-sm",
+          className
+        )}
+        {...props}
+      >
+        {children}
+      </div>
+    )
+  }
+
+  return (
+    <LiquidGlass
+      ref={ref}
+      className={cn("rounded-lg text-card-foreground", className)}
+      {...props}
+    >
+      {children}
+    </LiquidGlass>
+  )
+})
 Card.displayName = "Card"
 
 const CardHeader = React.forwardRef<


### PR DESCRIPTION
## Summary
- apply the liquid glass effect to all cards in light mode
- remove the "Liquid Glass UI" demo card

## Testing
- `pnpm install`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6848b856da188321afeefe82a1ff648b