### PR TITLE
Implement burn, tax and presale features

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+artifacts/
+cache/
+typechain-types/

--- a/contracts/Token.sol
+++ b/contracts/Token.sol
@@ -2,9 +2,87 @@
 pragma solidity ^0.8.20;
 
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
 
-contract Token is ERC20 {
-    constructor(string memory name, string memory symbol, uint256 supply) ERC20(name, symbol) {
+contract Token is ERC20, Ownable {
+    uint256 public burnPercentage; // in whole numbers (e.g. 2 for 2%)
+    uint256 public taxPercentage; // in whole numbers (e.g. 3 for 3%)
+    address public taxWallet;
+
+    bool public presaleActive;
+    uint256 public presaleEnd;
+
+    event BurnPercentageUpdated(uint256 newPercentage);
+    event TaxPercentageUpdated(uint256 newPercentage);
+    event TaxWalletUpdated(address newWallet);
+    event PresaleStarted(uint256 duration);
+    event PresaleEnded();
+
+    constructor(
+        string memory name,
+        string memory symbol,
+        uint256 supply,
+        uint256 _burnPercentage,
+        uint256 _taxPercentage,
+        address _taxWallet
+    ) ERC20(name, symbol) Ownable(msg.sender) {
+        require(_burnPercentage + _taxPercentage <= 100, "invalid percentages");
         _mint(msg.sender, supply);
+        burnPercentage = _burnPercentage;
+        taxPercentage = _taxPercentage;
+        taxWallet = _taxWallet;
+    }
+
+    // --- owner controls ---
+
+    function setBurnPercentage(uint256 value) external onlyOwner {
+        require(value + taxPercentage <= 100, "invalid burn");
+        burnPercentage = value;
+        emit BurnPercentageUpdated(value);
+    }
+
+    function setTaxPercentage(uint256 value) external onlyOwner {
+        require(value + burnPercentage <= 100, "invalid tax");
+        taxPercentage = value;
+        emit TaxPercentageUpdated(value);
+    }
+
+    function setTaxWallet(address wallet) external onlyOwner {
+        require(wallet != address(0), "zero addr");
+        taxWallet = wallet;
+        emit TaxWalletUpdated(wallet);
+    }
+
+    function startPresale(uint256 duration) external onlyOwner {
+        presaleActive = true;
+        presaleEnd = block.timestamp + duration;
+        emit PresaleStarted(duration);
+    }
+
+    function endPresale() external onlyOwner {
+        presaleActive = false;
+        emit PresaleEnded();
+    }
+
+    // --- internal ---
+
+    function _update(address from, address to, uint256 amount) internal override {
+        if (presaleActive && block.timestamp < presaleEnd) {
+            require(from == owner(), "presale in progress");
+        }
+
+        uint256 burnAmount = (amount * burnPercentage) / 100;
+        uint256 taxAmount = (amount * taxPercentage) / 100;
+        uint256 sendAmount = amount - burnAmount - taxAmount;
+
+        if (burnAmount > 0) {
+            super._update(from, address(0), burnAmount);
+        }
+
+        if (taxAmount > 0 && taxWallet != address(0)) {
+            super._update(from, taxWallet, taxAmount);
+        }
+
+        super._update(from, to, sendAmount);
     }
 }

--- a/lib/evm.ts
+++ b/lib/evm.ts
@@ -6,12 +6,22 @@ export async function deployEvmToken(
   privateKey: string,
   name: string,
   symbol: string,
-  supply: bigint
+  supply: bigint,
+  burnPercentage = 0n,
+  taxPercentage = 0n,
+  taxWallet: string | null = null
 ): Promise<string> {
   const provider = new ethers.JsonRpcProvider(rpcUrl);
   const wallet = new ethers.Wallet(privateKey, provider);
   const factory = new ethers.ContractFactory(TokenArtifact.abi, TokenArtifact.bytecode, wallet);
-  const token = await factory.deploy(name, symbol, supply);
+  const token = await factory.deploy(
+    name,
+    symbol,
+    supply,
+    Number(burnPercentage),
+    Number(taxPercentage),
+    taxWallet ?? ethers.ZeroAddress
+  );
   await token.waitForDeployment();
   return token.target as string;
 }

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
+    "prebuild": "hardhat compile",
     "build": "next build",
     "start": "next start",
     "lint": "next lint",

--- a/scripts/deploy-evm.ts
+++ b/scripts/deploy-evm.ts
@@ -5,7 +5,14 @@ async function main() {
   console.log("Deploying with", deployer.address);
 
   const Token = await ethers.getContractFactory("Token");
-  const token = await Token.deploy("MyToken", "MTK", ethers.parseUnits("1000000", 18));
+  const token = await Token.deploy(
+    "MyToken",
+    "MTK",
+    ethers.parseUnits("1000000", 18),
+    0,
+    0,
+    ethers.ZeroAddress
+  );
   await token.waitForDeployment();
 
   console.log("Token deployed to", token.target);


### PR DESCRIPTION
## Summary
- extend Token contract with burn percentage, transaction tax and presale controls
- update hardhat deployment script and EVM helper
- ignore build artifacts in git

## Testing
- `pnpm test`
- `npx hardhat compile`

------
https://chatgpt.com/codex/tasks/task_e_6849ec9a225c832195b581968da36fef