### PR TITLE
Add wallet selection and advanced token settings

### DIFF
--- a/app/api/launch/route.ts
+++ b/app/api/launch/route.ts
@@ -5,7 +5,16 @@ import { Keypair } from '@solana/web3.js';
 import fs from 'fs';
 
 export async function POST(req: NextRequest) {
-  const { chain, name, symbol, supply } = await req.json();
+  const {
+    chain,
+    name,
+    symbol,
+    supply,
+    rpcUrl,
+    burnRate,
+    transactionTax,
+    presaleDuration,
+  } = await req.json();
   if (!chain || !name || !symbol || !supply) {
     return NextResponse.json({ error: 'Missing parameters' }, { status: 400 });
   }
@@ -16,16 +25,36 @@ export async function POST(req: NextRequest) {
       const path = process.env.SOLANA_KEYPAIR ?? '';
       const secret = JSON.parse(fs.readFileSync(path, 'utf8')) as number[];
       const keypair = Keypair.fromSecretKey(new Uint8Array(secret));
-      const rpc = process.env.RPC_URL_SOLANA ?? '';
+      const rpc = rpcUrl || process.env.RPC_URL_SOLANA || '';
       address = await deploySolanaToken(rpc, keypair);
     } else if (chain === 'base') {
-      const rpc = process.env.RPC_URL_BASE ?? '';
+      const rpc = rpcUrl || process.env.RPC_URL_BASE || '';
       const pk = process.env.EVM_PRIVATE_KEY ?? '';
-      address = await deployEvmToken(rpc, pk, name, symbol, BigInt(supply));
+      address = await deployEvmToken(
+        rpc,
+        pk,
+        name,
+        symbol,
+        BigInt(supply),
+        BigInt(burnRate || 0),
+        BigInt(transactionTax || 0),
+        null,
+        BigInt(presaleDuration || 0)
+      );
     } else if (chain === 'avalanche') {
-      const rpc = process.env.RPC_URL_AVALANCHE ?? '';
+      const rpc = rpcUrl || process.env.RPC_URL_AVALANCHE || '';
       const pk = process.env.EVM_PRIVATE_KEY ?? '';
-      address = await deployEvmToken(rpc, pk, name, symbol, BigInt(supply));
+      address = await deployEvmToken(
+        rpc,
+        pk,
+        name,
+        symbol,
+        BigInt(supply),
+        BigInt(burnRate || 0),
+        BigInt(transactionTax || 0),
+        null,
+        BigInt(presaleDuration || 0)
+      );
     } else {
       return NextResponse.json({ error: 'Unsupported chain' }, { status: 400 });
     }

--- a/app/launch/page.tsx
+++ b/app/launch/page.tsx
@@ -23,12 +23,23 @@ interface LaunchForm {
   symbol: string
   image: string
   chain: string
+  wallet: string
+  rpcUrl: string
   supply: string
   lockDuration: string
   tokenomics: string
+  burnRate: string
+  transactionTax: string
+  presaleDuration: string
 }
 
-const steps = ["Token Details", "Select Blockchain", "Tokenomics"]
+const steps = [
+  "Token Details",
+  "Select Blockchain",
+  "Wallet & Network",
+  "Tokenomics",
+  "Advanced Settings",
+]
 
 export default function LaunchPage() {
   const form = useForm<LaunchForm>({
@@ -37,9 +48,14 @@ export default function LaunchPage() {
       symbol: "",
       image: "",
       chain: "",
+      wallet: "",
+      rpcUrl: "",
       supply: "",
       lockDuration: "",
       tokenomics: "",
+      burnRate: "",
+      transactionTax: "",
+      presaleDuration: "",
     },
   })
   const [step, setStep] = useState(0)
@@ -162,6 +178,22 @@ export default function LaunchPage() {
             {step === 2 && (
               <>
                 <div className="space-y-2">
+                  <label className="text-sm font-medium" htmlFor="wallet">
+                    Wallet Address
+                  </label>
+                  <Input id="wallet" {...form.register("wallet", { required: true })} />
+                </div>
+                <div className="space-y-2">
+                  <label className="text-sm font-medium" htmlFor="rpcUrl">
+                    RPC URL
+                  </label>
+                  <Input id="rpcUrl" {...form.register("rpcUrl", { required: true })} />
+                </div>
+              </>
+            )}
+            {step === 3 && (
+              <>
+                <div className="space-y-2">
                   <label className="text-sm font-medium" htmlFor="supply">
                     Total Supply
                   </label>
@@ -178,6 +210,28 @@ export default function LaunchPage() {
                     Tokenomics
                   </label>
                   <Textarea id="tokenomics" {...form.register("tokenomics")} />
+                </div>
+              </>
+            )}
+            {step === 4 && (
+              <>
+                <div className="space-y-2">
+                  <label className="text-sm font-medium" htmlFor="burnRate">
+                    Burn Rate (%)
+                  </label>
+                  <Input id="burnRate" type="number" {...form.register("burnRate")} />
+                </div>
+                <div className="space-y-2">
+                  <label className="text-sm font-medium" htmlFor="transactionTax">
+                    Transaction Tax (%)
+                  </label>
+                  <Input id="transactionTax" type="number" {...form.register("transactionTax")} />
+                </div>
+                <div className="space-y-2">
+                  <label className="text-sm font-medium" htmlFor="presaleDuration">
+                    Presale Duration (days)
+                  </label>
+                  <Input id="presaleDuration" type="number" {...form.register("presaleDuration")} />
                 </div>
               </>
             )}

--- a/components/launch-modal.tsx
+++ b/components/launch-modal.tsx
@@ -24,12 +24,23 @@ interface LaunchForm {
   symbol: string
   image: string
   chain: string
+  wallet: string
+  rpcUrl: string
   supply: string
   lockDuration: string
   tokenomics: string
+  burnRate: string
+  transactionTax: string
+  presaleDuration: string
 }
 
-const steps = ["Token Details", "Select Blockchain", "Tokenomics"]
+const steps = [
+  "Token Details",
+  "Select Blockchain",
+  "Wallet & Network",
+  "Tokenomics",
+  "Advanced Settings",
+]
 
 interface LaunchModalProps {
   children: React.ReactNode
@@ -42,9 +53,14 @@ export default function LaunchModal({ children }: LaunchModalProps) {
       symbol: "",
       image: "",
       chain: "",
+      wallet: "",
+      rpcUrl: "",
       supply: "",
       lockDuration: "",
       tokenomics: "",
+      burnRate: "",
+      transactionTax: "",
+      presaleDuration: "",
     },
   })
   const [step, setStep] = useState(0)
@@ -52,8 +68,18 @@ export default function LaunchModal({ children }: LaunchModalProps) {
   const next = () => setStep((s) => Math.min(s + 1, steps.length - 1))
   const back = () => setStep((s) => Math.max(s - 1, 0))
 
-  const onSubmit = (values: LaunchForm) => {
-    console.log("Submitted", values)
+  const onSubmit = async (values: LaunchForm) => {
+    const res = await fetch("/api/launch", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(values),
+    })
+    if (!res.ok) {
+      console.error("Deployment failed")
+    } else {
+      const data = await res.json()
+      console.log("Deployed", data.address)
+    }
   }
 
   return (
@@ -111,6 +137,22 @@ export default function LaunchModal({ children }: LaunchModalProps) {
               {step === 2 && (
                 <>
                   <div className="space-y-2">
+                    <label className="text-sm font-medium" htmlFor="wallet">
+                      Wallet Address
+                    </label>
+                    <Input id="wallet" {...form.register("wallet", { required: true })} />
+                  </div>
+                  <div className="space-y-2">
+                    <label className="text-sm font-medium" htmlFor="rpcUrl">
+                      RPC URL
+                    </label>
+                    <Input id="rpcUrl" {...form.register("rpcUrl", { required: true })} />
+                  </div>
+                </>
+              )}
+              {step === 3 && (
+                <>
+                  <div className="space-y-2">
                     <label className="text-sm font-medium" htmlFor="supply">
                       Total Supply
                     </label>
@@ -135,6 +177,28 @@ export default function LaunchModal({ children }: LaunchModalProps) {
                       Tokenomics
                     </label>
                     <Textarea id="tokenomics" {...form.register("tokenomics")} />
+                  </div>
+                </>
+              )}
+              {step === 4 && (
+                <>
+                  <div className="space-y-2">
+                    <label className="text-sm font-medium" htmlFor="burnRate">
+                      Burn Rate (%)
+                    </label>
+                    <Input id="burnRate" type="number" {...form.register("burnRate")} />
+                  </div>
+                  <div className="space-y-2">
+                    <label className="text-sm font-medium" htmlFor="transactionTax">
+                      Transaction Tax (%)
+                    </label>
+                    <Input id="transactionTax" type="number" {...form.register("transactionTax")} />
+                  </div>
+                  <div className="space-y-2">
+                    <label className="text-sm font-medium" htmlFor="presaleDuration">
+                      Presale Duration (days)
+                    </label>
+                    <Input id="presaleDuration" type="number" {...form.register("presaleDuration")} />
                   </div>
                 </>
               )}

--- a/lib/evm.ts
+++ b/lib/evm.ts
@@ -9,7 +9,8 @@ export async function deployEvmToken(
   supply: bigint,
   burnPercentage = 0n,
   taxPercentage = 0n,
-  taxWallet: string | null = null
+  taxWallet: string | null = null,
+  presaleDuration = 0n
 ): Promise<string> {
   const provider = new ethers.JsonRpcProvider(rpcUrl);
   const wallet = new ethers.Wallet(privateKey, provider);
@@ -23,5 +24,9 @@ export async function deployEvmToken(
     taxWallet ?? ethers.ZeroAddress
   );
   await token.waitForDeployment();
+  if (presaleDuration > 0n) {
+    const tx = await token.startPresale(presaleDuration);
+    await tx.wait();
+  }
   return token.target as string;
 }


### PR DESCRIPTION
## Summary
- extend Launch Wizard with wallet address and RPC URL fields
- add burn rate, transaction tax, and presale duration inputs
- pass new fields to API and EVM deploy logic

## Testing
- `pnpm install`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6849ffc9844c8321b9bad01c14927e3a