### PR TITLE
Add Solana Anchor placeholders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ next-env.d.ts
 artifacts/
 cache/
 typechain-types/
+solana/**/target/

--- a/README.md
+++ b/README.md
@@ -17,7 +17,9 @@
   Verify tweet ownership and reward engaged users with automated airdrops.
 
 - **Liquidity Protection**
-  Enforce automatic liquidity locks and unlock timers to prevent rug pulls.
+  Enforce automatic liquidity locks and unlock timers to prevent rug pulls. A
+  placeholder Anchor program (`solana/liquidity-lock`) demonstrates the Solana
+  implementation.
 - **Presale Escrow**
   Investor funds are held in smart-contract escrow until the presale is finalized.
 - **Audit Status Badges**
@@ -34,7 +36,7 @@
 |--------------|----------------------------------------|
 | Frontend      | React + Tailwind (OpenAI design system) |
 | Backend       | Next.js / Express                     | 
-| Blockchain    | Solana (SPL), EVM (Base, Avalanche)   |
+| Blockchain    | Solana (SPL/Anchor), EVM (Base, Avalanche)   |
 | Smart Contracts | Solidity, Anchor                    |
 | Analytics     | Custom RPC queries / Subgraphs        |
 | Distribution  | Twitter API (OAuth, RT verification)  |

--- a/lib/liquidity-lock.ts
+++ b/lib/liquidity-lock.ts
@@ -18,3 +18,35 @@ export async function deployLiquidityLock(
   await lock.waitForDeployment();
   return lock.target as string;
 }
+
+/**
+ * Placeholder for deploying a Solana liquidity locking program using Anchor.
+ * The underlying program should accept a token mint and lock duration.
+ */
+export async function deploySolanaLiquidityLock(
+  rpcUrl: string,
+  payer: import("@solana/web3.js").Keypair,
+  programId: import("@solana/web3.js").PublicKey,
+  mint: import("@solana/web3.js").PublicKey,
+  duration: number
+): Promise<string> {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const anchor = require("@coral-xyz/anchor");
+  const connection = new (require("@solana/web3.js").Connection)(rpcUrl, "confirmed");
+  const provider = new anchor.AnchorProvider(connection, new anchor.Wallet(payer), {});
+  const idl = await anchor.Program.fetchIdl(programId, provider);
+  if (!idl) throw new Error("Anchor IDL not found for liquidity lock");
+  const program = new anchor.Program(idl, programId, provider);
+  const lockAccount = anchor.web3.Keypair.generate();
+  await program.methods
+    .initialize(new anchor.BN(duration))
+    .accounts({
+      lock: lockAccount.publicKey,
+      mint,
+      payer: payer.publicKey,
+      systemProgram: anchor.web3.SystemProgram.programId,
+    })
+    .signers([lockAccount])
+    .rpc();
+  return lockAccount.publicKey.toBase58();
+}

--- a/lib/solana.ts
+++ b/lib/solana.ts
@@ -1,5 +1,8 @@
-import { Connection, Keypair } from "@solana/web3.js";
+import { Connection, Keypair, PublicKey } from "@solana/web3.js";
 import { createMint } from "@solana/spl-token";
+// Anchor is optional and only used for the advanced deployer
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const anchor = require("@coral-xyz/anchor");
 
 export async function deploySolanaToken(
   rpcUrl: string,
@@ -9,4 +12,33 @@ export async function deploySolanaToken(
   const connection = new Connection(rpcUrl, "confirmed");
   const mint = await createMint(connection, payer, payer.publicKey, null, decimals);
   return mint.toBase58();
+}
+
+/**
+ * Anchor-based token deployer. This is a placeholder implementation that
+ * expects an Anchor program capable of initializing a new mint. The program
+ * should expose an `initialize_mint` instruction taking the desired decimals.
+ */
+export async function deploySolanaTokenAnchor(
+  rpcUrl: string,
+  payer: Keypair,
+  programId: PublicKey,
+  decimals = 9
+): Promise<string> {
+  const connection = new Connection(rpcUrl, "confirmed");
+  const provider = new anchor.AnchorProvider(connection, new anchor.Wallet(payer), {});
+  const idl = await anchor.Program.fetchIdl(programId, provider);
+  if (!idl) throw new Error("Anchor IDL not found for deployer program");
+  const program = new anchor.Program(idl, programId, provider);
+  const mint = Keypair.generate();
+  await program.methods
+    .initializeMint(new anchor.BN(decimals))
+    .accounts({
+      mint: mint.publicKey,
+      payer: payer.publicKey,
+      systemProgram: anchor.web3.SystemProgram.programId,
+    })
+    .signers([mint])
+    .rpc();
+  return mint.publicKey.toBase58();
 }

--- a/solana/liquidity-lock/Anchor.toml
+++ b/solana/liquidity-lock/Anchor.toml
@@ -1,0 +1,8 @@
+[programs.localnet]
+liquidity_lock = "Placeholder11111111111111111111111111111111"
+
+[provider]
+cluster = "localnet"
+wallet = "~/.config/solana/id.json"
+
+[scripts]

--- a/solana/liquidity-lock/programs/liquidity-lock/Cargo.toml
+++ b/solana/liquidity-lock/programs/liquidity-lock/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "liquidity-lock"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+anchor-lang = "0.30.0"

--- a/solana/liquidity-lock/programs/liquidity-lock/src/lib.rs
+++ b/solana/liquidity-lock/programs/liquidity-lock/src/lib.rs
@@ -1,0 +1,20 @@
+use anchor_lang::prelude::*;
+
+declare_id!("Placeholder11111111111111111111111111111111");
+
+#[program]
+pub mod liquidity_lock {
+    use super::*;
+
+    pub fn initialize(_ctx: Context<Initialize>, _lock_duration: u64) -> Result<()> {
+        // Placeholder logic for initializing a liquidity lock
+        Ok(())
+    }
+}
+
+#[derive(Accounts)]
+pub struct Initialize<'info> {
+    #[account(mut)]
+    pub payer: Signer<'info>,
+    pub system_program: Program<'info, System>,
+}


### PR DESCRIPTION
## Summary
- add placeholder LiquidityLock Anchor program for Solana
- extend `lib/solana.ts` with an Anchor-based deployer
- expose Solana liquidity lock deployer in `lib/liquidity-lock.ts`
- document Anchor support and placeholder program in README
- ignore Anchor `target` directories

## Testing
- `pnpm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b2ca9c81c83219c71980fe001ca98