### PR TITLE
Add tests for blockchain libraries

### DIFF
--- a/lib/__tests__/bridge.test.ts
+++ b/lib/__tests__/bridge.test.ts
@@ -1,0 +1,70 @@
+import { bridgeViaAxelar, bridgeViaLayerZero } from '../bridge';
+
+const transferWait = jest.fn();
+const transferMock = jest.fn().mockResolvedValue({ wait: transferWait });
+const sendWait = jest.fn().mockResolvedValue({ hash: '0xhash' });
+const sendFromMock = jest.fn().mockResolvedValue({ wait: sendWait });
+
+jest.mock('@layerzerolabs/oft-evm/artifacts/contracts/oft/OFT.sol/OFT.json', () => ({
+  abi: [],
+}), { virtual: true });
+
+jest.mock('@axelar-network/axelarjs-sdk', () => ({
+  AxelarAssetTransfer: jest.fn().mockImplementation(() => ({
+    getDepositAddress: jest.fn().mockResolvedValue('deposit'),
+  })),
+  Environment: { MAINNET: 'mainnet' },
+}), { virtual: true });
+
+jest.mock('ethers', () => ({
+  ethers: {
+    JsonRpcProvider: jest.fn(),
+    Wallet: jest.fn().mockImplementation(() => ({ address: 'wallet' })),
+    Contract: jest.fn().mockImplementation(() => ({ transfer: transferMock, sendFrom: sendFromMock })),
+    ZeroAddress: '0x0000000000000000000000000000000000000000',
+    solidityPacked: jest.fn().mockReturnValue('packed'),
+  },
+}), { virtual: true });
+
+describe('bridgeViaAxelar', () => {
+  beforeEach(() => { transferMock.mockClear(); transferWait.mockClear(); });
+
+  it('transfers tokens to deposit address', async () => {
+    const addr = await bridgeViaAxelar({
+      rpcUrl: 'url',
+      privateKey: 'pk',
+      fromChain: 'A',
+      toChain: 'B',
+      tokenAddress: 'token',
+      amount: 1n,
+      destinationAddress: 'dest',
+    });
+    expect(transferMock).toHaveBeenCalledWith('deposit', 1n);
+    expect(addr).toBe('deposit');
+  });
+});
+
+describe('bridgeViaLayerZero', () => {
+  beforeEach(() => { sendFromMock.mockClear(); sendWait.mockClear(); });
+
+  it('calls sendFrom and returns hash', async () => {
+    const hash = await bridgeViaLayerZero({
+      rpcUrl: 'url',
+      privateKey: 'pk',
+      oftAddress: 'oft',
+      dstChainId: 2,
+      amount: 5n,
+      destinationAddress: 'dest',
+    });
+    expect(sendFromMock).toHaveBeenCalledWith(
+      'wallet',
+      2,
+      'packed',
+      5n,
+      'wallet',
+      '0x0000000000000000000000000000000000000000',
+      '0x'
+    );
+    expect(hash).toBe('0xhash');
+  });
+});

--- a/lib/__tests__/distribution.test.ts
+++ b/lib/__tests__/distribution.test.ts
@@ -1,0 +1,40 @@
+import { distributeTokens } from '../token-distribution';
+
+const waitMock = jest.fn();
+const transferMock = jest.fn().mockResolvedValue({ wait: waitMock });
+const decimalsMock = jest.fn().mockResolvedValue(6);
+
+jest.mock('ethers', () => ({
+  ethers: {
+    JsonRpcProvider: jest.fn(),
+    Wallet: jest.fn(),
+    Contract: jest.fn().mockImplementation(() => ({
+      decimals: decimalsMock,
+      transfer: transferMock,
+    })),
+    parseUnits: jest.fn().mockImplementation((a, b) => `${a}-${b}`),
+  },
+}), { virtual: true });
+
+describe('distributeTokens', () => {
+  beforeEach(() => {
+    waitMock.mockClear();
+    transferMock.mockClear();
+    decimalsMock.mockClear();
+    process.env.AIRDROP_RPC_URL = 'url';
+    process.env.EVM_PRIVATE_KEY = 'pk';
+    process.env.AIRDROP_TOKEN_ADDRESS = 'token';
+    process.env.AIRDROP_AMOUNT = '1';
+  });
+
+  it('throws when env is missing', async () => {
+    delete process.env.AIRDROP_RPC_URL;
+    await expect(distributeTokens('user')).rejects.toThrow('Token distribution environment not configured');
+  });
+
+  it('transfers tokens to user', async () => {
+    await distributeTokens('user');
+    expect(decimalsMock).toHaveBeenCalled();
+    expect(transferMock).toHaveBeenCalledWith('user', '1-6');
+  });
+});

--- a/lib/__tests__/evm.test.ts
+++ b/lib/__tests__/evm.test.ts
@@ -1,0 +1,42 @@
+import { deployEvmToken } from '../evm';
+
+jest.mock('../../artifacts/contracts/Token.sol/Token.json', () => ({
+  abi: [],
+  bytecode: '0x',
+}), { virtual: true });
+
+const startPresaleMock = jest.fn().mockResolvedValue({ wait: jest.fn() });
+const deployMock = jest.fn().mockResolvedValue({
+  waitForDeployment: jest.fn(),
+  startPresale: startPresaleMock,
+  target: '0xtoken',
+});
+
+jest.mock('ethers', () => ({
+  ethers: {
+    JsonRpcProvider: jest.fn(),
+    Wallet: jest.fn().mockImplementation(() => ({ address: '0xwallet' })),
+    ContractFactory: jest.fn().mockImplementation(() => ({ deploy: deployMock })),
+    ZeroAddress: '0x0000000000000000000000000000000000000000',
+  },
+}), { virtual: true });
+
+describe('deployEvmToken', () => {
+  beforeEach(() => {
+    startPresaleMock.mockClear();
+    deployMock.mockClear();
+  });
+
+  it('deploys token without presale', async () => {
+    const address = await deployEvmToken('url', 'pk', 'A', 'A', 18, 1000n);
+    expect(deployMock).toHaveBeenCalledWith('A', 'A', 18, 1000n, 0, 0, '0x0000000000000000000000000000000000000000');
+    expect(startPresaleMock).not.toHaveBeenCalled();
+    expect(address).toBe('0xtoken');
+  });
+
+  it('starts presale when duration provided', async () => {
+    const address = await deployEvmToken('url', 'pk', 'B', 'B', 18, 1000n, 0n, 0n, null, 10n);
+    expect(startPresaleMock).toHaveBeenCalledWith(10n);
+    expect(address).toBe('0xtoken');
+  });
+});

--- a/lib/__tests__/liquidity-lock.test.ts
+++ b/lib/__tests__/liquidity-lock.test.ts
@@ -1,0 +1,29 @@
+import { deployLiquidityLock } from '../liquidity-lock';
+
+jest.mock('../../artifacts/contracts/LiquidityLock.sol/LiquidityLock.json', () => ({
+  abi: [],
+  bytecode: '0x',
+}), { virtual: true });
+
+const deployMock = jest.fn().mockResolvedValue({
+  waitForDeployment: jest.fn(),
+  target: '0xlock',
+});
+
+jest.mock('ethers', () => ({
+  ethers: {
+    JsonRpcProvider: jest.fn(),
+    Wallet: jest.fn(),
+    ContractFactory: jest.fn().mockImplementation(() => ({ deploy: deployMock })),
+  },
+}), { virtual: true });
+
+describe('deployLiquidityLock', () => {
+  beforeEach(() => deployMock.mockClear());
+
+  it('deploys lock contract', async () => {
+    const address = await deployLiquidityLock('url', 'pk', '0xtoken', 5n);
+    expect(deployMock).toHaveBeenCalledWith('0xtoken', 5);
+    expect(address).toBe('0xlock');
+  });
+});

--- a/lib/__tests__/presale.test.ts
+++ b/lib/__tests__/presale.test.ts
@@ -1,0 +1,29 @@
+import { deployPresaleEscrow } from '../presale';
+
+jest.mock('../../artifacts/contracts/PresaleEscrow.sol/PresaleEscrow.json', () => ({
+  abi: [],
+  bytecode: '0x',
+}), { virtual: true });
+
+const deployMock = jest.fn().mockResolvedValue({
+  waitForDeployment: jest.fn(),
+  target: '0xescrow',
+});
+
+jest.mock('ethers', () => ({
+  ethers: {
+    JsonRpcProvider: jest.fn(),
+    Wallet: jest.fn(),
+    ContractFactory: jest.fn().mockImplementation(() => ({ deploy: deployMock })),
+  },
+}), { virtual: true });
+
+describe('deployPresaleEscrow', () => {
+  beforeEach(() => deployMock.mockClear());
+
+  it('deploys escrow contract', async () => {
+    const address = await deployPresaleEscrow('url', 'pk');
+    expect(deployMock).toHaveBeenCalled();
+    expect(address).toBe('0xescrow');
+  });
+});

--- a/lib/__tests__/solana.test.ts
+++ b/lib/__tests__/solana.test.ts
@@ -1,0 +1,21 @@
+jest.mock('@coral-xyz/anchor', () => ({}), { virtual: true });
+jest.mock('@solana/spl-token', () => ({ createMint: jest.fn() }), { virtual: true });
+jest.mock('@solana/web3.js', () => ({
+  Connection: jest.fn(),
+  Keypair: {},
+  PublicKey: jest.fn(),
+}), { virtual: true });
+
+import { deploySolanaToken } from '../solana';
+import { createMint } from '@solana/spl-token';
+import type { Keypair } from '@solana/web3.js';
+
+describe('deploySolanaToken', () => {
+  it('creates a new mint and returns its address', async () => {
+    (createMint as jest.Mock).mockResolvedValue({ toBase58: () => 'mint' });
+    const payer = { publicKey: 'pub' } as unknown as Keypair;
+    const address = await deploySolanaToken('url', payer, 8);
+    expect(createMint).toHaveBeenCalledWith(expect.anything(), payer, payer.publicKey, null, 8);
+    expect(address).toBe('mint');
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for EVM, Solana and bridging helpers
- add tests for token distribution and contract deployment helpers

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_684ca4c49e5c83218d5045a4841451d3