### PR TITLE
Add reusable Steps component

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -31,6 +31,7 @@ import {
 import Link from "next/link"
 import Image from "next/image"
 import HeroCard from "@/components/hero-card"
+import Steps from "@/components/steps"
 import { AuditBadge } from "@/components/audit-badge"
 
 const CheckIcon = () => <CheckCircle2 className="h-5 w-5 text-green-500" />
@@ -214,50 +215,25 @@ export default function TokenForgePage() {
                 Three Steps to Token Success
               </motion.h2>
             </div>
-            <div className="flex flex-col gap-8">
-              {[
+            <Steps
+              steps={[
                 {
-                  icon: Settings,
-                  title: "1. Create Token",
-                  content:
-                    "Configure everything in minutes—name, ticker, total supply, and launch chains. Choose from battle-tested mechanics like automatic burns, transaction fees, and time-locked liquidity that protect your community from day one.",
-                  image: "/launchimage.png",
+                  title: "Create Token",
+                  subtitle: "Configure everything in minutes—name, ticker, supply and launch chains.",
+                  message: "Welcome to the Plain startup program! 🎉",
                 },
                 {
-                  icon: Target,
-                  title: "Step 2: Choose Your Launch Strategy",
-                  content:
-                    'Go public instantly, create an exclusive whitelist, or run a presale. Our viral "Tweet-to-Mint" feature turns every social share into token distribution, building your community as you launch.',
-                  image: "/placeholder.jpg",
+                  title: "Choose Your Launch Strategy",
+                  subtitle: "Go public instantly or run a presale with Tweet-to-Mint.",
+                  message: "Welcome to the Plain startup program! 🎉",
                 },
                 {
-                  icon: Sparkles,
-                  title: "Step 3: Launch with Full Transparency",
-                  content:
-                    "Your token goes live with real-time analytics, automatic leaderboard placement, and complete on-chain tracking. Every holder can see burn logs, price movements, and liquidity status in real-time.",
-                  image: "/placeholder.jpg",
+                  title: "Launch with Full Transparency",
+                  subtitle: "Real-time analytics, automatic leaderboard placement and liquidity locks.",
+                  message: "Welcome to the Plain startup program! 🎉",
                 },
-              ].map((item, index) => (
-                <MotionCard
-                  key={item.title}
-                  variants={itemVariants}
-                  className="bg-background border-0 p-6 md:p-8 text-left flex flex-col shadow-lg hover:shadow-xl transition-shadow duration-300"
-                >
-                  <div className="flex-shrink-0 mb-4">
-                    <item.icon className="h-10 w-10 text-primary" />
-                  </div>
-                  <h3 className="text-xl md:text-2xl font-semibold mb-3">{item.title}</h3>
-                  <p className="text-muted-foreground text-sm md:text-base mb-4 flex-grow">{item.content}</p>
-                  <Image
-                    src={item.image}
-                    alt={item.title}
-                    width={400}
-                    height={300}
-                    className="rounded-lg border border-border/20 object-cover"
-                  />
-                </MotionCard>
-              ))}
-            </div>
+              ]}
+            />
           </div>
         </motion.section>
 

--- a/components/steps/index.tsx
+++ b/components/steps/index.tsx
@@ -1,0 +1,28 @@
+import Step from "./step";
+
+export interface StepData {
+  title: string;
+  subtitle?: string;
+  message: string;
+}
+
+interface StepsProps {
+  steps: StepData[];
+}
+
+export default function Steps({ steps }: StepsProps) {
+  return (
+    <div className="grid gap-12">
+      {steps.map((step, idx) => (
+        <Step
+          key={idx}
+          number={idx + 1}
+          title={step.title}
+          subtitle={step.subtitle}
+          message={step.message}
+        />
+      ))}
+    </div>
+  );
+}
+export { Step };

--- a/components/steps/step.tsx
+++ b/components/steps/step.tsx
@@ -1,0 +1,45 @@
+import { Avatar, AvatarFallback } from "@/components/ui/avatar";
+import { Card, CardContent } from "@/components/ui/card";
+
+interface StepProps {
+  number: number;
+  title: string;
+  subtitle?: string;
+  message: string;
+  sender?: string;
+  recipient?: string;
+}
+
+export default function Step({
+  number,
+  title,
+  subtitle,
+  message,
+  sender = "Simon @ Plain",
+  recipient = "to you",
+}: StepProps) {
+  return (
+    <div className="flex flex-col items-center text-center space-y-4">
+      <div className="bg-black text-white rounded-md px-3 py-1 text-sm font-medium shadow" data-testid="step-number">
+        {number}
+      </div>
+      <h3 className="text-xl font-bold">{title}</h3>
+      {subtitle && <p className="text-sm text-muted-foreground max-w-md">{subtitle}</p>}
+      <Card className="bg-muted/20 w-full max-w-md shadow-sm">
+        <CardContent className="p-4 flex gap-3 items-start">
+          <Avatar className="h-8 w-8">
+            <AvatarFallback>P.</AvatarFallback>
+          </Avatar>
+          <div className="text-left flex-1 space-y-1">
+            <div className="text-sm">
+              <span className="font-medium text-foreground">{sender}</span>{" "}
+              <span className="text-muted-foreground">{recipient}</span>
+            </div>
+            <p className="font-semibold text-foreground">{message}</p>
+            <div className="h-3 w-full bg-muted rounded-md blur-sm" />
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- implement `Step` component with step number, title, subtitle and message card
- create `Steps` wrapper for mapping through step data
- replace the "Three Steps" section on homepage to use new Steps component

## Testing
- `pnpm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d7e796c9883218a2622a3dd9eb8b1