### PR TITLE
Add CodeForge token details

### DIFF
--- a/app/tokens/[symbol]/page.tsx
+++ b/app/tokens/[symbol]/page.tsx
@@ -59,6 +59,12 @@ export default function TokenDetailPage() {
                   <div className="font-medium">Chain</div>
                   <div>{token.chain}</div>
                 </div>
+                {token.status && (
+                  <div className="space-y-1">
+                    <div className="font-medium">Status</div>
+                    <div>{token.status}</div>
+                  </div>
+                )}
                 <div className="space-y-1">
                   <div className="font-medium">Website</div>
                   <div>
@@ -79,7 +85,30 @@ export default function TokenDetailPage() {
                   <div className="font-medium">Total Supply</div>
                   <div>{token.totalSupply}</div>
                 </div>
+                {token.liquidityLock && (
+                  <div className="space-y-1">
+                    <div className="font-medium">Liquidity Lock</div>
+                    <div>{token.liquidityLock}</div>
+                  </div>
+                )}
               </div>
+
+              {token.tokenomics && (
+                <div className="grid grid-cols-3 gap-4 text-sm">
+                  <div className="space-y-1">
+                    <div className="font-medium">Burn</div>
+                    <div>{token.tokenomics.burn}</div>
+                  </div>
+                  <div className="space-y-1">
+                    <div className="font-medium">Tax</div>
+                    <div>{token.tokenomics.tax}</div>
+                  </div>
+                  <div className="space-y-1">
+                    <div className="font-medium">LP</div>
+                    <div>{token.tokenomics.lp}</div>
+                  </div>
+                </div>
+              )}
 
               <div>
                 <div className="flex justify-between text-sm font-medium mb-1">
@@ -106,6 +135,24 @@ export default function TokenDetailPage() {
               </div>
 
               <Button className="w-full">Back This Token</Button>
+
+              {token.shareLink && (
+                <div className="mt-4 space-y-2 text-sm">
+                  <div className="font-medium">Shareable Link</div>
+                  <div>
+                    <Link href={token.shareLink} className="text-primary underline" target="_blank" rel="noopener noreferrer">
+                      {token.shareLink}
+                    </Link>
+                  </div>
+                  <Button
+                    onClick={() => navigator.clipboard.writeText(token.shareLink!)}
+                    variant="secondary"
+                    className="w-full mt-2"
+                  >
+                    Copy Link
+                  </Button>
+                </div>
+              )}
             </CardContent>
           </Card>
         </div>

--- a/components/trending-token-card.tsx
+++ b/components/trending-token-card.tsx
@@ -16,6 +16,14 @@ export interface TrendingToken {
   launchDate?: string
   launchPrice?: string
   totalSupply?: string
+  status?: string
+  liquidityLock?: string
+  tokenomics?: {
+    burn?: string
+    tax?: string
+    lp?: string
+  }
+  shareLink?: string
 }
 
 export default function TrendingTokenCard({

--- a/lib/tokens.ts
+++ b/lib/tokens.ts
@@ -91,4 +91,29 @@ export const tokens: TrendingToken[] = [
     launchPrice: "0.015 ETH",
     totalSupply: "750M",
   },
+  {
+    name: "CodeForge",
+    symbol: "CFRG",
+    chain: "Base",
+    description:
+      "A utility token for a decentralized software development platform.",
+    progress: 0,
+    raised: "0 ETH",
+    goal: "100.000 ETH",
+    backers: 0,
+    daysLeft: 30,
+    status: "Upcoming",
+    liquidityLock: "730 Days",
+    tokenomics: {
+      burn: "2%",
+      tax: "3%",
+      lp: "60%",
+    },
+    website: undefined,
+    launchDate: undefined,
+    launchPrice: undefined,
+    totalSupply: undefined,
+    shareLink:
+      "https://6000-firebase-studio-1750035540971.cluster-jbb3mjctu5cbgsi6hwq6u4btwe.cloudworkstations.dev/token/4",
+  },
 ]


### PR DESCRIPTION
## Summary
- extend token model with optional status, liquidity info, tokenomics, and share link
- add CodeForge token entry using new fields
- show extra fields on token detail page

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68502e3475f48321a5e3763ee12406e0