### PR TITLE
Refactor token detail layout

### DIFF
--- a/app/tokens/[symbol]/page.tsx
+++ b/app/tokens/[symbol]/page.tsx
@@ -45,7 +45,7 @@ export default function TokenDetailPage() {
         </div>
       </header>
       <main className="flex-1 py-12">
-        <div className="container mx-auto max-w-2xl px-4 md:px-6">
+        <div className="container mx-auto max-w-2xl px-4 md:px-6 space-y-6">
           <Card className="rounded-xl border border-border/20 bg-card/80 backdrop-blur shadow-xl">
             <CardHeader className="space-y-1">
               <CardTitle className="text-2xl font-bold">
@@ -53,63 +53,79 @@ export default function TokenDetailPage() {
               </CardTitle>
               <p className="text-sm text-muted-foreground">{token.description}</p>
             </CardHeader>
-            <CardContent className="space-y-6">
-              <div className="grid grid-cols-2 gap-4 text-sm">
-                <div className="space-y-1">
-                  <div className="font-medium">Chain</div>
-                  <div>{token.chain}</div>
-                </div>
-                {token.status && (
-                  <div className="space-y-1">
-                    <div className="font-medium">Status</div>
-                    <div>{token.status}</div>
-                  </div>
-                )}
-                <div className="space-y-1">
-                  <div className="font-medium">Website</div>
-                  <div>
-                    <Link href={token.website ?? '#'} className="text-primary underline" target="_blank" rel="noopener noreferrer">
-                      {token.website}
-                    </Link>
-                  </div>
-                </div>
-                <div className="space-y-1">
-                  <div className="font-medium">Launch Date</div>
-                  <div>{token.launchDate}</div>
-                </div>
-                <div className="space-y-1">
-                  <div className="font-medium">Launch Price</div>
-                  <div>{token.launchPrice}</div>
-                </div>
-                <div className="space-y-1">
-                  <div className="font-medium">Total Supply</div>
-                  <div>{token.totalSupply}</div>
-                </div>
-                {token.liquidityLock && (
-                  <div className="space-y-1">
-                    <div className="font-medium">Liquidity Lock</div>
-                    <div>{token.liquidityLock}</div>
-                  </div>
-                )}
-              </div>
+          </Card>
 
-              {token.tokenomics && (
-                <div className="grid grid-cols-3 gap-4 text-sm">
-                  <div className="space-y-1">
-                    <div className="font-medium">Burn</div>
-                    <div>{token.tokenomics.burn}</div>
-                  </div>
-                  <div className="space-y-1">
-                    <div className="font-medium">Tax</div>
-                    <div>{token.tokenomics.tax}</div>
-                  </div>
-                  <div className="space-y-1">
-                    <div className="font-medium">LP</div>
-                    <div>{token.tokenomics.lp}</div>
-                  </div>
+          <Card className="rounded-xl border border-border/20 bg-card/80 backdrop-blur shadow-xl">
+            <CardHeader>
+              <CardTitle>Details</CardTitle>
+            </CardHeader>
+            <CardContent className="grid grid-cols-2 gap-4 text-sm">
+              <div className="space-y-1">
+                <div className="font-medium">Chain</div>
+                <div>{token.chain}</div>
+              </div>
+              {token.status && (
+                <div className="space-y-1">
+                  <div className="font-medium">Status</div>
+                  <div>{token.status}</div>
                 </div>
               )}
+              <div className="space-y-1">
+                <div className="font-medium">Website</div>
+                <div>
+                  <Link href={token.website ?? '#'} className="text-primary underline" target="_blank" rel="noopener noreferrer">
+                    {token.website}
+                  </Link>
+                </div>
+              </div>
+              <div className="space-y-1">
+                <div className="font-medium">Launch Date</div>
+                <div>{token.launchDate}</div>
+              </div>
+              <div className="space-y-1">
+                <div className="font-medium">Launch Price</div>
+                <div>{token.launchPrice}</div>
+              </div>
+              <div className="space-y-1">
+                <div className="font-medium">Total Supply</div>
+                <div>{token.totalSupply}</div>
+              </div>
+              {token.liquidityLock && (
+                <div className="space-y-1">
+                  <div className="font-medium">Liquidity Lock</div>
+                  <div>{token.liquidityLock}</div>
+                </div>
+              )}
+            </CardContent>
+          </Card>
 
+          {token.tokenomics && (
+            <Card className="rounded-xl border border-border/20 bg-card/80 backdrop-blur shadow-xl">
+              <CardHeader>
+                <CardTitle>Tokenomics</CardTitle>
+              </CardHeader>
+              <CardContent className="grid grid-cols-3 gap-4 text-sm">
+                <div className="space-y-1">
+                  <div className="font-medium">Burn</div>
+                  <div>{token.tokenomics.burn}</div>
+                </div>
+                <div className="space-y-1">
+                  <div className="font-medium">Tax</div>
+                  <div>{token.tokenomics.tax}</div>
+                </div>
+                <div className="space-y-1">
+                  <div className="font-medium">LP</div>
+                  <div>{token.tokenomics.lp}</div>
+                </div>
+              </CardContent>
+            </Card>
+          )}
+
+          <Card className="rounded-xl border border-border/20 bg-card/80 backdrop-blur shadow-xl">
+            <CardHeader>
+              <CardTitle>Funding</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-6">
               <div>
                 <div className="flex justify-between text-sm font-medium mb-1">
                   <span>Funding Progress</span>


### PR DESCRIPTION
## Summary
- split token detail page into multiple cards: overview, details, tokenomics, funding

## Testing
- `pnpm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685061f5294483219ca4819479752064