### PR TITLE
Adjust launch modal width and remove header

### DIFF
--- a/components/launch-modal.tsx
+++ b/components/launch-modal.tsx
@@ -139,8 +139,8 @@ export default function LaunchModal({ children }: LaunchModalProps) {
   return (
     <Dialog>
       <DialogTrigger asChild>{children}</DialogTrigger>
-      <DialogContent className="p-0 border-none bg-transparent">
-        <Card className="max-w-xl mx-auto rounded-xl border border-border/20 bg-card/80 backdrop-blur shadow-xl">
+      <DialogContent className="p-0 border-none bg-transparent max-w-4xl">
+        <Card className="max-w-4xl mx-auto rounded-xl border border-border/20 bg-card/80 backdrop-blur shadow-xl">
           <CardHeader className="space-y-4">
             <Stepper steps={steps} currentStep={step} />
             <CardTitle className="text-center">{steps[step]}</CardTitle>

--- a/components/token-proposal-form.tsx
+++ b/components/token-proposal-form.tsx
@@ -82,9 +82,6 @@ export default function TokenProposalForm() {
 
   return (
     <Card className="rounded-xl border border-border/20 bg-card/80 backdrop-blur shadow-xl">
-      <CardHeader>
-        <CardTitle>Launch a Token</CardTitle>
-      </CardHeader>
       <CardContent>
         <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
           <div className="space-y-2">


### PR DESCRIPTION
## Summary
- widen the launch modal
- remove the Launch a Token heading from the proposal form

## Testing
- `pnpm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850802c4da483218de900e4fa7fe986