### PR TITLE
Add automatic compile for testnet launch

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ M5    Token discovery dashboard    1 wk
 To deploy example tokens on test networks, populate the environment variables from `.env.example` with testnet RPC URLs and keys. Then run:
 
 ```bash
-pnpm ts-node scripts/launch-testnet.ts <chain>
+pnpm run launch-testnet -- <chain>
 ```
 
-`<chain>` can be `base`, `avalanche`, or `solana`. The script prints the address of the newly deployed token on the selected network.
+`<chain>` can be `base`, `avalanche`, or `solana`. The script automatically compiles the smart contracts if needed and prints the address of the newly deployed token on the selected network.

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "test": "jest"
+    "test": "jest",
+    "launch-testnet": "ts-node scripts/launch-testnet.ts"
   },
   "dependencies": {
     "@axelar-network/axelarjs-sdk": "^0.17.4",

--- a/scripts/launch-testnet.ts
+++ b/scripts/launch-testnet.ts
@@ -2,6 +2,22 @@ import { deployEvmToken } from '../lib/evm';
 import { deploySolanaToken } from '../lib/solana';
 import { Keypair } from '@solana/web3.js';
 import fs from 'fs';
+import path from 'path';
+import { execSync } from 'child_process';
+
+// Ensure contract artifacts exist for EVM deployments
+const artifact = path.join(
+  __dirname,
+  '..',
+  'artifacts',
+  'contracts',
+  'Token.sol',
+  'Token.json'
+);
+if (!fs.existsSync(artifact)) {
+  console.log('Compiling contracts...');
+  execSync('pnpm hardhat compile', { stdio: 'inherit' });
+}
 
 async function main() {
   const chain = process.argv[2];


### PR DESCRIPTION
## Summary
- add `launch-testnet` npm script
- automatically compile contracts if artifacts are missing when launching tokens
- update docs for testnet launch instructions

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6851ce1defa08321a553230a49ebb8d3